### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,6 +3,10 @@
 
 name: Node.js CI Build
 
+permissions:
+  contents: read
+  pull-requests: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/bmordue/graph-browser/security/code-scanning/3](https://github.com/bmordue/graph-browser/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's steps:
- `contents: read` is sufficient for most steps, such as checking out the repository and running tests.
- `pull-requests: read` is required for the `SonarQube Scan` step to fetch pull request information.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `build` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
